### PR TITLE
feat: add LastWill and Session configuration messages to MQTT client

### DIFF
--- a/ciot/proto/v2/mqtt_client.proto
+++ b/ciot/proto/v2/mqtt_client.proto
@@ -45,20 +45,34 @@ message MqttClientTopicsCfg {
   string sub = 2; // Topic used to receive data.
 }
 
+message MqttClientLastWill {
+  string topic = 1;  // Topic for the last will message.
+  bytes payload = 2; // Payload for the last will message.
+  uint32 qos = 3;    // Quality of Service level for the last will message.
+  bool retain = 4;   // Retain flag for the last will message.
+}
+
 // Message used to stop MQTT client interface
 message MqttClientStop {
 
 }
 
+message MqttClientSessionCfg {
+  bool clean_session = 1; // Clean session flag
+  int32 keep_alive = 2;    // Keep alive interval in seconds
+}
+
 // Message representing configuration for the MQTT client.
 message MqttClientCfg {
-  string client_id = 1;                 // Client ID for MQTT connection.
-  string url = 2;                       // URL for MQTT connection.
-  string user = 3;                      // Username for MQTT authentication.
-  string password = 4;                  // Password for MQTT authentication.
-  uint32 qos = 5;                       // Quality of Service level for MQTT communication.
-  MqttClientTopicsCfg topics = 6;       // Topics configuration for MQTT communication.
-  MqttClientBrokerKind broker_kind = 7; // MQTT broker kind
+  string client_id = 1;                       // Client ID for MQTT connection.
+  string url = 2;                             // URL for MQTT connection.
+  string user = 3;                            // Username for MQTT authentication.
+  string password = 4;                        // Password for MQTT authentication.
+  uint32 qos = 5;                             // Quality of Service level for MQTT communication.
+  MqttClientTopicsCfg topics = 6;             // Topics configuration for MQTT communication.
+  MqttClientBrokerKind broker_kind = 7;       // MQTT broker kind.
+  optional MqttClientLastWill last_will = 8;  // Last will message configuration.
+  optional MqttClientSessionCfg session = 9;  // Session configuration.
 }
 
 // Message representing status information for the MQTT client.


### PR DESCRIPTION
This pull request updates the MQTT client protocol buffer definitions to support more advanced MQTT features. The key changes are the addition of message types for last will and session configuration, and their integration into the main MQTT client configuration.

#### New MQTT feature support

* Added a new `MqttClientLastWill` message type to represent the configuration for MQTT "last will" messages, including topic, payload, QoS, and retain flag.
* Added a new `MqttClientSessionCfg` message type to represent session configuration, including clean session flag and keep alive interval.

#### Integration into main configuration

* Updated the `MqttClientCfg` message to include optional `last_will` and `session` fields, allowing clients to specify last will and session configuration directly in their main configuration.